### PR TITLE
Watcom: Use inline files instead of external files

### DIFF
--- a/SOURCE/INTMON.LNK
+++ b/SOURCE/INTMON.LNK
@@ -1,5 +1,0 @@
-system	dos
-name	intmon
-file	intmon.obj, a20.obj, disp.obj, disp_a.obj, gate.obj, int.obj,
-	int_a.obj, intfunc.obj, pmem.obj, proto_a.obj, seg.obj, segtolin.obj,
-	task.obj, task_a.obj, trans_a.obj, v86.obj, v86_a.obj

--- a/SOURCE/IOMON.LNK
+++ b/SOURCE/IOMON.LNK
@@ -1,5 +1,0 @@
-system	dos
-name	iomon
-file	iomon.obj, a20.obj, disp.obj, disp_a.obj, gate.obj, int.obj, int_a.obj,
-	intfunc.obj, ioaudit.obj, ioemu_a.obj, pmem.obj, proto_a.obj, seg.obj,
-	segtolin.obj, task.obj, task_a.obj, trans_a.obj, v86.obj, v86_a.obj

--- a/SOURCE/MAKEFILE.OW
+++ b/SOURCE/MAKEFILE.OW
@@ -71,8 +71,10 @@ sieve32.exe:	sieve32.obj a20.obj proto_a.obj seg.obj segtolin.obj &
 
 testgate.exe:	testgate.obj disp.obj disp_a.obj gate.obj int.obj int_a.obj &
 		intfunc.obj proto_a.obj seg.obj  segtolin.obj task.obj &
-		task_a.obj testgate.lnk
-	wlink @testgate.lnk
+		task_a.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<
 
 hardint.exe:	hardint.obj disp.obj disp_a.obj gate.obj gpe_a.obj int.obj &
 		int_a.obj intfunc.obj proto_a.obj seg.obj segtolin.obj
@@ -84,19 +86,25 @@ fault.exe:	fault.obj disp.obj disp_a.obj gate.obj gpe_a.obj int.obj &
 
 testtask.exe:	testtask.obj disp.obj disp_a.obj gate.obj int.obj int_a.obj &
 		intfunc.obj proto_a.obj seg.obj segtolin.obj task.obj &
-		task_a.obj testtask.lnk
-	wlink @testtask.lnk
+		task_a.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<
 
 vsieve.exe:	vsieve.obj a20.obj disp.obj disp_a.obj file.obj gate.obj &
 		int.obj int_a.obj intfunc.obj page.obj page_a.obj proto_a.obj &
-		seg.obj segtolin.obj sieve_a.obj trans_a.obj vm.obj vsieve.lnk
-	wlink @vsieve.lnk
+		seg.obj segtolin.obj sieve_a.obj trans_a.obj vm.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<
 
 intmon.exe:	intmon.obj a20.obj disp.obj disp_a.obj gate.obj int.obj &
 		int_a.obj intfunc.obj pmem.obj proto_a.obj seg.obj &
 		segtolin.obj task.obj task_a.obj trans_a.obj v86.obj &
-		v86_a.obj intmon.lnk
-	wlink @intmon.lnk
+		v86_a.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<
 
 dpmiinfo.exe:	dpmiinfo.obj dpmi.obj dpmi_a.obj
 	$(LD) $(LDFLAGS) $<
@@ -106,12 +114,15 @@ dpmisiev.exe:	dpmisiev.obj dpmi.obj dpmi_a.obj sieve_a.obj segtolin.obj
 
 revfile.exe:	revfile.obj a20.obj disp.obj disp_a.obj file.obj gate.obj &
 		int.obj int_a.obj intfunc.obj page.obj page_a.obj &
-		proto_a.obj rev_a.obj seg.obj segtolin.obj trans_a.obj vm.obj &
-		revfile.lnk
-	wlink @revfile.lnk
+		proto_a.obj rev_a.obj seg.obj segtolin.obj trans_a.obj vm.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<
 
 iomon.exe:	iomon.obj a20.obj disp.obj disp_a.obj gate.obj int.obj &
 		int_a.obj intfunc.obj ioaudit.obj ioemu_a.obj pmem.obj &
 		proto_a.obj seg.obj segtolin.obj task.obj task_a.obj &
-		trans_a.obj v86.obj v86_a.obj iomon.lnk
-	wlink @iomon.lnk
+		trans_a.obj v86.obj v86_a.obj
+	wlink system dos name $@ @<<
+file { $< }
+<<

--- a/SOURCE/REVFILE.LNK
+++ b/SOURCE/REVFILE.LNK
@@ -1,5 +1,0 @@
-system	dos
-name	revfile
-file	revfile.obj, a20.obj, disp.obj, disp_a.obj, file.obj, gate.obj,
-	int.obj, int_a.obj, intfunc.obj, page.obj, page_a.obj, proto_a.obj,
-	rev_a.obj, seg.obj, segtolin.obj, trans_a.obj, vm.obj

--- a/SOURCE/TESTGATE.LNK
+++ b/SOURCE/TESTGATE.LNK
@@ -1,4 +1,0 @@
-system	dos
-name	testgate
-file	testgate.obj, disp.obj, disp_a.obj, gate.obj, int.obj, int_a.obj,
-	intfunc.obj, proto_a.obj, seg.obj, segtolin.obj, task.obj, task_a.obj

--- a/SOURCE/TESTTASK.LNK
+++ b/SOURCE/TESTTASK.LNK
@@ -1,4 +1,0 @@
-system	dos
-name	testtask
-file	testtask.obj, disp.obj, disp_a.obj, gate.obj, int.obj, int_a.obj,
-	intfunc.obj, proto_a.obj, seg.obj, segtolin.obj, task.obj, task_a.obj

--- a/SOURCE/VSIEVE.LNK
+++ b/SOURCE/VSIEVE.LNK
@@ -1,5 +1,0 @@
-system	dos
-name	vsieve
-file	vsieve.obj, a20.obj, disp.obj, disp_a.obj, file.obj, gate.obj, int.obj,
-	int_a.obj, intfunc.obj, page.obj, page_a.obj, proto_a.obj, seg.obj,
-	segtolin.obj, sieve_a.obj, trans_a.obj, vm.obj


### PR DESCRIPTION
OpenWatcomのMakefileで、wlinkへの入力として外部ファイル (*.lnk) を使用していたのを、インラインファイルを使用するように変更しました。
