### PR TITLE
Add a mode to use BIOS to enable A20 line

### DIFF
--- a/SOURCE/A20.C
+++ b/SOURCE/A20.C
@@ -21,6 +21,10 @@ void EnableA20(void)
 {
 #ifdef PC98
     outp(0xf2,0);
+#elif defined(USE_BIOS_FOR_A20) /* PC/AT BIOS */
+    union REGS reg;
+    reg.x.ax = 0x2401;
+    int86(0x15, &reg, &reg);
 #else /* PC/AT */
     while(inp(0x64)&2);
     outp(0x64,0xd1);
@@ -31,4 +35,3 @@ void EnableA20(void)
     while(inp(0x64)&2);
 #endif
 }
-


### PR DESCRIPTION
A20ラインの制御にBIOSを使用するモードを追加しました。
`USE_BIOS_FOR_A20` が定義されていると、従来のキーボードコントローラではなく、BIOSの int 15h ax=2401h を使ってA20を有効化します。

参考:
http://www.win.tue.nl/~aeb/linux/kbd/A20.html
http://wiki.osdev.org/A20_Line

これを使うことで、[MS-DOS Player for Win32-x64](http://homepage3.nifty.com/takeda-toshiya/msdos/)上でsieve32が動くようになりました。
