### PR TITLE
fix type casting

### DIFF
--- a/SOURCE/DISP.C
+++ b/SOURCE/DISP.C
@@ -23,7 +23,7 @@ unsigned int VramSel;
 void InitDisp(void)
 {
     VramSel = AllocSel();
-    SetSegDesc(VramSel, SegToLinier(VRAMSEG,0), 0x2000,
+    SetSegDesc(VramSel, SegToLinear(VRAMSEG,0), 0x2000,
             TypeData, SmallSeg, 3);
 #ifdef PC98
     ScreenWidth = 80;

--- a/SOURCE/DPMISIEV.C
+++ b/SOURCE/DPMISIEV.C
@@ -46,7 +46,7 @@ void main(int argc, char *argv[])
 
     csel = DPMIAllocLDT();
     DPMISetRights(csel, TypeCode+0x60, Code386);
-    DPMISetBaseAddr(csel, SegToLinier(csseg32, 0));
+    DPMISetBaseAddr(csel, SegToLinear(csseg32, 0));
     DPMISetLimit(csel, codesize);
     sieveFunc = (void (__far *)() )
         (((unsigned long)csel<<16) + (unsigned short) sieve);

--- a/SOURCE/FAULT.C
+++ b/SOURCE/FAULT.C
@@ -29,7 +29,7 @@ void main(void)
     SetUpIDT(0);
 
     sel = AllocSel();
-    SetSegDesc(sel, SegToLinier(seg.ds, 0), 0x03ff,
+    SetSegDesc(sel, SegToLinear(seg.ds, 0), 0x03ff,
                                        TypeData, SmallSeg, 0);
 
     RealToProto_I(1);

--- a/SOURCE/FILE.C
+++ b/SOURCE/FILE.C
@@ -34,7 +34,7 @@ int ReadFile(int fd, unsigned long buf, int count)
     RealToProto_P(0);
 
     MemTransfer(buf,
-       SegToLinier(seg.ds, (unsigned short) dosbuf), (long) r);
+       SegToLinear(seg.ds, (unsigned short) dosbuf), (long) r);
     return r;
 }
 
@@ -42,7 +42,7 @@ int WriteFile(int fd, unsigned long buf, int count)
 {
     int r;
 
-    MemTransfer(SegToLinier(seg.ds, (unsigned short) dosbuf),
+    MemTransfer(SegToLinear(seg.ds, (unsigned short) dosbuf),
                                             buf, (long) count);
 
     ProtoToReal_P();

--- a/SOURCE/INT.C
+++ b/SOURCE/INT.C
@@ -49,7 +49,7 @@ void SetUpIDT(unsigned char dpl)
     SetIDTGateDesc(0x0d, 0x08, GPEFault, 0, TypeTrapGate, dpl);
 
     idtptr.limit = IDTNUM*sizeof(GateDesc);
-    idtptr.base  = SegToLinier(seg.ds, (unsigned short) idt);
+    idtptr.base  = SegToLinear(seg.ds, (unsigned short) idt);
     ridtptr.limit = 0x3ff;
     ridtptr.base  = 0;
 

--- a/SOURCE/PAGE.C
+++ b/SOURCE/PAGE.C
@@ -66,9 +66,9 @@ void SetUpPTE(void)
     }
 
     segread(&seg);
-    p = SegToLinier(seg.ds, (unsigned short)ptr);
+    p = SegToLinear(seg.ds, (unsigned short)ptr);
     p = (p+0xfff)&0xfffff000;
-    ptr = (unsigned char *)(p-SegToLinier(seg.ds,0));
+    ptr = (unsigned char *)(p-SegToLinear(seg.ds,0));
 
     PageDir = (unsigned long *)ptr;
     ptr+=PAGESIZE;
@@ -76,13 +76,13 @@ void SetUpPTE(void)
         PageTbl[i] = (unsigned long *)ptr;
 
     for (i=0;i<MAXDIRNUM;i++)
-        PageDir[i] = MakePTE(SegToLinier(seg.ds,
+        PageDir[i] = MakePTE(SegToLinear(seg.ds,
                     (unsigned short)PageTbl[i]));
 
     for (p=0;p<(long)MAXDIRNUM*PAGENUM*PAGESIZE;p+=PAGESIZE)
         SetPTE(p,p);
 
-    lcr3(SegToLinier(seg.ds,(unsigned short)PageDir));
+    lcr3(SegToLinear(seg.ds,(unsigned short)PageDir));
 }
 
 /*

--- a/SOURCE/PMEM.C
+++ b/SOURCE/PMEM.C
@@ -31,7 +31,7 @@ void InitPmemBuf(void)
 void SetPmemBufSize(unsigned long m)
 {
     MemTransfer(0x100000L,
-        SegToLinier(seg.ds, (unsigned short)&m),
+        SegToLinear(seg.ds, (unsigned short)&m),
         (unsigned long) sizeof(m));
 }
 
@@ -39,7 +39,7 @@ unsigned long GetPmemBufSize()
 {
     unsigned long m;
 
-    MemTransfer(SegToLinier(seg.ds, (unsigned short)&m),
+    MemTransfer(SegToLinear(seg.ds, (unsigned short)&m),
         0x100000L, (unsigned long) sizeof(m));
     return m;
 }
@@ -50,7 +50,7 @@ void PutPmemBuf(char *buf, unsigned long m)
 
     s = GetPmemBufSize();
     MemTransfer(0x100000L+sizeof(s)+s,
-        SegToLinier(seg.ds, (unsigned short)buf), m);
+        SegToLinear(seg.ds, (unsigned short)buf), m);
     SetPmemBufSize(s+m);
 }
 
@@ -60,7 +60,7 @@ unsigned long GetPmemBuf(char *buf, unsigned long s, unsigned long m)
 
     mm = min(GetPmemBufSize()-s, m);
     if (mm>0)
-        MemTransfer( SegToLinier(seg.ds, (unsigned short)buf),
+        MemTransfer( SegToLinear(seg.ds, (unsigned short)buf),
             0x100000L+sizeof(s)+s, mm);
     return mm;
 }

--- a/SOURCE/PROTO.H
+++ b/SOURCE/PROTO.H
@@ -80,7 +80,7 @@ void SetSegDesc(
   unsigned char segtype,
   unsigned char seg32type,
   unsigned char dpl);
-unsigned long SegToLinier(unsigned short seg,
+unsigned long SegToLinear(unsigned short seg,
                                            unsigned short off);
 void          SetUpGDT(void);
 void          InitDisp(void);

--- a/SOURCE/SEG.C
+++ b/SOURCE/SEG.C
@@ -42,10 +42,10 @@ void MakeSegDesc(
   unsigned char seg32type,
   unsigned char dpl)
 {
-    desc->baseL = (unsigned int) (addr & 0xffff);
+    desc->baseL = (unsigned short) (addr & 0xffff);
     desc->baseM = (unsigned char) ((addr >> 16) & 0xff);
     desc->baseH = (unsigned char) ((addr >> 24) & 0xff);
-    desc->limitL = (unsigned int) (limit & 0xffff);
+    desc->limitL = (unsigned short) (limit & 0xffff);
     desc->limitH = (unsigned char) ((limit >> 16) & 0x0f)
                                                   + seg32type;
 

--- a/SOURCE/SEG.C
+++ b/SOURCE/SEG.C
@@ -97,15 +97,15 @@ void SetUpGDT(void)
     datasize=0xffff;
     stacksize=0; /*(unsigned short) sbrk(0);*/
 
-    SetSegDesc(0x08, SegToLinier(seg.cs, 0),
+    SetSegDesc(0x08, SegToLinear(seg.cs, 0),
                              codesize, TypeCode, SmallSeg, 0);
-    SetSegDesc(0x10, SegToLinier(seg.ds, 0),
+    SetSegDesc(0x10, SegToLinear(seg.ds, 0),
                              datasize, TypeData, SmallSeg, 0);
-    SetSegDesc(0x18, SegToLinier(seg.ss, 0),
+    SetSegDesc(0x18, SegToLinear(seg.ss, 0),
                            stacksize, TypeStack, SmallSeg, 0);
-    SetSegDesc(0x20, SegToLinier(seg.cs, 0),
+    SetSegDesc(0x20, SegToLinear(seg.cs, 0),
                                0xffff, TypeCode, SmallSeg, 0);
-    SetSegDesc(0x28, SegToLinier(seg.ds, 0),
+    SetSegDesc(0x28, SegToLinear(seg.ds, 0),
                                0xffff, TypeData, SmallSeg, 0);
     SetSegDesc(0x30, 0L, 0xfffff, TypeData, BigSeg, 3);
 
@@ -115,7 +115,7 @@ void SetUpGDT(void)
  */
 
     gdtptr.limit = GDTNUM*sizeof(SegDesc) -1;
-    gdtptr.base  = SegToLinier(seg.ds, (unsigned short) gdt);
+    gdtptr.base  = SegToLinear(seg.ds, (unsigned short) gdt);
 
     lgdt(&gdtptr);
 }

--- a/SOURCE/SEGTOLIN.C
+++ b/SOURCE/SEGTOLIN.C
@@ -9,14 +9,14 @@
  */
 
 /*
- *    List 5-10  リニアアドレスを計算するSegToLinier()関数
+ *    List 5-10  リニアアドレスを計算するSegToLinear()関数
  *               [segtolin.c  1/1] (page 153)
  */
 
 #include <dos.h>
 #include "proto.h"
 
-unsigned long SegToLinier(unsigned short seg,
+unsigned long SegToLinear(unsigned short seg,
                                           unsigned short off)
 {
     return ((unsigned long)seg<<4) + off;

--- a/SOURCE/SIEVE32.C
+++ b/SOURCE/SIEVE32.C
@@ -41,7 +41,7 @@ void main(int argc, char *argv[])
     EnableA20();
 
     sel = AllocSel();
-    SetSegDesc(sel, SegToLinier(csseg32, 0),
+    SetSegDesc(sel, SegToLinear(csseg32, 0),
                                 0xffff, TypeCode, Code386, 0);
     sieveFunc = (void (__far *)() )
           (((unsigned long)sel<<16) + (unsigned short) sieve);

--- a/SOURCE/TESTGATE.C
+++ b/SOURCE/TESTGATE.C
@@ -45,23 +45,23 @@ void main(void)
     InitDisp();
 
     selcseg = AllocSel();
-    SetSegDesc(selcseg, SegToLinier(seg.cs, 0), 0xffff,
+    SetSegDesc(selcseg, SegToLinear(seg.cs, 0), 0xffff,
         TypeCode, SmallSeg, 3);
     seldseg = AllocSel();
-    SetSegDesc(seldseg, SegToLinier(seg.ds, 0), 0xffff,
+    SetSegDesc(seldseg, SegToLinear(seg.ds, 0), 0xffff,
         TypeData, SmallSeg, 3);
     selsseg = AllocSel();
-    SetSegDesc(selsseg, SegToLinier(seg.ss, 0), 0,
+    SetSegDesc(selsseg, SegToLinear(seg.ss, 0), 0,
         TypeStack, SmallSeg, 3);
 
     seltss_os = AllocSel();
     SetSegDesc(seltss_os,
-               SegToLinier(seg.ds, (unsigned short) &tss_os),
+               SegToLinear(seg.ds, (unsigned short) &tss_os),
                      (long) sizeof(TSS), TypeTSS, SmallSeg, 0);
 
     seltss_app = AllocSel();
     SetSegDesc(seltss_app,
-               SegToLinier(seg.ds, (unsigned short) &tss_app),
+               SegToLinear(seg.ds, (unsigned short) &tss_app),
                      (long) sizeof(TSS), TypeTSS, SmallSeg, 3);
     SetTSS( &tss_app, selcseg|3, seldseg,
                   AppMain, 0, stack_app+STACKSIZE,

--- a/SOURCE/TESTTASK.C
+++ b/SOURCE/TESTTASK.C
@@ -124,13 +124,13 @@ void SetUpTSS(void)
                   stack[1] +STACKSIZE, 0x10, NULL, 0);
 
     SetSegDesc(TaskList[0],
-           SegToLinier(seg.ds, (unsigned short) tss),
+           SegToLinear(seg.ds, (unsigned short) tss),
                (long) sizeof(TSS), TypeTSS, SmallSeg, 0);
     SetSegDesc(TaskList[1],
-           SegToLinier(seg.ds, (unsigned short) (tss+1)),
+           SegToLinear(seg.ds, (unsigned short) (tss+1)),
                (long) sizeof(TSS), TypeTSS, SmallSeg, 0);
     SetSegDesc(TaskList[2],
-           SegToLinier(seg.ds, (unsigned short) (tss+2)),
+           SegToLinear(seg.ds, (unsigned short) (tss+2)),
                (long) sizeof(TSS), TypeTSS, SmallSeg, 0);
 }
 

--- a/SOURCE/V86.C
+++ b/SOURCE/V86.C
@@ -51,11 +51,11 @@ void SetV86(void (*f)())
 
     ProtoTssSel = AllocSel();
     SetSegDesc(ProtoTssSel,
-        SegToLinier(seg.ds, (unsigned short) &tss),
+        SegToLinear(seg.ds, (unsigned short) &tss),
             (long) sizeof(TSS), TypeTSS, SmallSeg, 0);
     V86TssSel = AllocSel();
     SetSegDesc(V86TssSel,
-        SegToLinier(seg.ds, (unsigned short) &v86tss),
+        SegToLinear(seg.ds, (unsigned short) &v86tss),
             (long) sizeof(TSS_IO), TypeTSS, SmallSeg, 0);
 
     IntHandler = v86int;

--- a/SOURCE/VSIEVE.C
+++ b/SOURCE/VSIEVE.C
@@ -56,7 +56,7 @@ void main(int argc, char *argv[])
     EnableA20();
 
     sel = AllocSel();
-    SetSegDesc(sel, SegToLinier(csseg32, 0),
+    SetSegDesc(sel, SegToLinear(csseg32, 0),
                                 0xffff, TypeCode, Code386, 0);
     sieveFunc = (void (__far *)() )
         (((unsigned long)sel<<16) + (unsigned short) sieve);
@@ -70,7 +70,7 @@ void main(int argc, char *argv[])
         fprintf(stderr, "Can't alloc memory\n");
         exit(1);
     }
-    ptop = SegToLinier(seg.ds, (unsigned short)ptop+PAGESIZE) & 0xfffff000;
+    ptop = SegToLinear(seg.ds, (unsigned short)ptop+PAGESIZE) & 0xfffff000;
     VMInit(ptop, PHYSSIZE, TBLADR, TBLSIZE);
     VMMapFile(swapfile);
 


### PR DESCRIPTION
For commit 9d4c35b624cef3eac8c2c9619e4092c6df8c1ca7, fix type casting  of `limitL` and `baseL` (`unsigned int` -> `unsigned short`).

https://github.com/tkmc/486/blob/master/SOURCE/PROTO.H#L18-L19
```
typedef struct _SegDesc {
    unsigned short limitL;
    unsigned short baseL;
```